### PR TITLE
Place reply send button at the trailing edge of the field

### DIFF
--- a/Toast.qml
+++ b/Toast.qml
@@ -812,10 +812,12 @@ Item {
               Keys.onEscapePressed: { text = ""; card.replyCancelled() }
 
               // Enter sends, but an affordance nobody can see is not one.
+              // Sits at the trailing edge of the field. When the first
+              // directional character is Arabic or Hebrew the field reads
+              // right-to-left, so "trailing" means left.
               Button {
                 id: sendButton
-                anchors.right: parent.right
-                anchors.rightMargin: Style.space(4)
+                x: isRtl ? Style.space(4) : parent.width - width - Style.space(4)
                 anchors.verticalCenter: parent.verticalCenter
                 visible: replyInput.text.length > 0
                 text: "Send"
@@ -826,6 +828,23 @@ Item {
                 fontSize: Style.font.caption
                 verticalPadding: 1
                 onClicked: { card.replySent(replyInput.text); replyInput.text = "" }
+
+                // True when the reply text starts with an RTL script.
+                // Skips spaces, digits, and punctuation to find the first
+                // character that actually has a direction.
+                property bool isRtl: {
+                  var t = replyInput.text;
+                  for (var i = 0; i < t.length; i++) {
+                    var c = t.charCodeAt(i);
+                    if (c < 0x41) continue;                         // skip ASCII controls, digits, punctuation
+                    if (c <= 0x024F) return false;                  // Latin
+                    if (c >= 0x0590 && c <= 0x08FF) return true;    // Hebrew, Arabic, Syriac, Thaana (Dhivehi)
+                    if (c >= 0xFB50 && c <= 0xFDFF) return true;    // Arabic Presentation Forms-A
+                    if (c >= 0xFE70 && c <= 0xFEFF) return true;    // Arabic Presentation Forms-B
+                    return false;
+                  }
+                  return false;
+                }
               }
             }
 

--- a/Toast.qml
+++ b/Toast.qml
@@ -830,17 +830,21 @@ Item {
                 onClicked: { card.replySent(replyInput.text); replyInput.text = "" }
 
                 // True when the reply text starts with an RTL script.
-                // Skips spaces, digits, and punctuation to find the first
-                // character that actually has a direction.
+                // Skips anything without a strong direction (spaces,
+                // digits, brackets, punctuation) to find the first
+                // character that actually picks a side. 
                 property bool isRtl: {
                   var t = replyInput.text;
-                  for (var i = 0; i < t.length; i++) {
-                    var c = t.charCodeAt(i);
-                    if (c < 0x41) continue;                         // skip ASCII controls, digits, punctuation
-                    if (c <= 0x024F) return false;                  // Latin
-                    if (c >= 0x0590 && c <= 0x08FF) return true;    // Hebrew, Arabic, Syriac, Thaana (Dhivehi)
-                    if (c >= 0xFB50 && c <= 0xFDFF) return true;    // Arabic Presentation Forms-A
-                    if (c >= 0xFE70 && c <= 0xFEFF) return true;    // Arabic Presentation Forms-B
+                  for (var i = 0; i < t.length;) {
+                    var c = t.codePointAt(i);
+                    i += c > 0xFFFF ? 2 : 1;                         // step past surrogate pairs
+                    if (c <= 0x7F && !(c >= 0x41 && c <= 0x5A)
+                                  && !(c >= 0x61 && c <= 0x7A))
+                      continue;                                       // skip all ASCII non-letters
+                    if (c <= 0x024F) return false;                    // Latin
+                    if (c >= 0x0590 && c <= 0x08FF) return true;      // Hebrew, Arabic, Syriac, Thaana
+                    if (c >= 0xFB50 && c <= 0xFDFF) return true;      // Arabic Presentation Forms-A
+                    if (c >= 0xFE70 && c <= 0xFEFF) return true;      // Arabic Presentation Forms-B
                     return false;
                   }
                   return false;


### PR DESCRIPTION
### Problem
The `Send` button inside the reply field was hardcoded to `anchors.right`. When typing in a right-to-left language (such as Arabic or Hebrew), the text starts on the right side of the field, causing it to collide with and get hidden beneath the button.

#### Before (Overlap Issue)
<img width="620" height="295" alt="image" src="https://github.com/user-attachments/assets/59595f0c-80b7-4169-958a-496246ced7e6" />

### Solution
Replaced the static right anchor with an `x` position binding that checks the first directional character in the input:
- **LTR text:** The button rests on the right edge.
- **RTL text:** The button dynamically shifts to the left edge.

The script detection skips leading whitespace, numbers, and punctuation so inputs like `"123 مرحبا"` still register as RTL correctly.


### Results

The `Send` button now dynamically anchors to the opposing side of the text origin for both directions:

| LTR Input | RTL Input |
| :---: | :---: |
| <img width="637" height="271" alt="image" src="https://github.com/user-attachments/assets/c88cd306-e8b4-402d-8dc8-d66fa3c6f7a2" /> | <img width="652" height="262" alt="image" src="https://github.com/user-attachments/assets/5fb0e909-1a48-4e7a-a032-c280034a236e" /> |
